### PR TITLE
Add --quiet flag that hides console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ If you don't like the hashed selection, experiment with
 variations. You might hate `--hash js`, but find
 `--hash js_`, `--hash JS` or `--hash javascript` to be just right
 
+By default, tabset will show output indicating what color was picked
+if no color was explicitly provided, such as when using the `--hash`
+option, `--pick`, or `--all` flags. If you want to disable this
+output, you can use the `--quiet` flag, and there will be no terminal
+output indicating what color was chosen.
+
 Titles and Badges
 -----------------
 

--- a/tabset.js
+++ b/tabset.js
@@ -43,6 +43,15 @@ var config = readJSON(configpath) || { colors: {} }
 interpretConfig(config)
 process_args()
 
+/**
+ * Proxy to println that does nothing if --quiet flag is passed.
+ */
+function sayln () {
+  if (!args.quiet) {
+    println(...arguments);
+  }
+}
+
 function process_args () {
   // help requested
   if (args.help) {
@@ -66,6 +75,7 @@ function process_args () {
     println('       --del <name>')
     println('       --list')
     println('       --colors')
+    println('       --quiet')
     println('       --help')
     println()
   }
@@ -93,7 +103,7 @@ function process_args () {
       var colorNames = _.keys(colors).sort()
       var index = stringHash(args.all) % colorNames.length
       var hashColor = colorNames[index]
-      println('picked color:', hashColor)
+      sayln('picked color:', hashColor)
       col = colors[hashColor]
     }
     setTabColor(col, definedOr(args.mode, 1))
@@ -125,18 +135,18 @@ function process_args () {
       colorpick({ targetApp: 'iTerm2'},
                 function (res) {
                   addColor(args.add, rgbstr(res.rgb))
-                  println('added:', args.add)
+                  sayln('added:', args.add)
                 })
     } else if (_.size(args._) === 1) {
       addColor(args.add, args._[0])
-      println('added:', args.add)
+      sayln('added:', args.add)
     } else {
       errorExit('add what color?')
     }
   } else if (args.pick) {
     colorpick({ targetApp: 'iTerm2'},
               function (res) {
-                println('picked:', rgbstr(res.rgb))
+                sayln('picked:', rgbstr(res.rgb))
                 setTabColor(res.rgb)
               })
   }
@@ -146,7 +156,7 @@ function process_args () {
       errorExit('must give name to delete')
     }
     delColor(args.del)
-    println('deleted:', args.del)
+    sayln('deleted:', args.del)
   }
 
   if (args.list) {
@@ -289,7 +299,7 @@ function decodeColor (name) {
     if (args.hash) {
       var index = stringHash(args.hash) % colorNames.length
       var hashColor = colorNames[index]
-      println('hashed color:', hashColor)
+      sayln('hashed color:', hashColor)
       return colors[hashColor]
     }
 
@@ -300,14 +310,14 @@ function decodeColor (name) {
   // random named color
   if (name === 'random') {
     var randColor = _.sample(colorNames)
-    println('random color:', randColor)
+    sayln('random color:', randColor)
     return colors[randColor]
   }
 
   // RANDOM color - not just a random named color
   if (name === 'RANDOM') {
     var rcolor = [_.random(255), _.random(255), _.random(255) ]
-    println('RANDOM color:', rgbstr(rcolor))
+    sayln('RANDOM color:', rgbstr(rcolor))
     return rcolor
   }
 
@@ -324,20 +334,20 @@ function decodeColor (name) {
       return s.indexOf(name) >= 0
     })
     if (possibles.length === 1) {
-      println('guessing:', possibles[0])
+      sayln('guessing:', possibles[0])
       return colors[possibles[0]]
     }  else if (possibles.length > 1) {
-      println(wrap('possibly: ' + possibles.join(', ')))
+      sayln(wrap('possibly: ' + possibles.join(', ')))
       var rcolor = _.sample(possibles)
-      println('randomly picked:', rcolor)
+      sayln('randomly picked:', rcolor)
       return colors[rcolor]
     }
   }
 
   // nothing worked, use default color
-  println('no color', JSON.stringify(name), 'known')
-  println('using default:', defaultColorSpec)
-  println('use --colors option to list color names')
+  sayln('no color', JSON.stringify(name), 'known')
+  sayln('using default:', defaultColorSpec)
+  sayln('use --colors option to list color names')
   return colors['default']
 }
 


### PR DESCRIPTION
fixes #4 

In this PR as it is now, a few options still have output and the `--quiet` flag is ignored. For instance, `--list` and `--colors` ignore `--quiet` because their sole purpose is output to the console.

Now, if users pass `--quiet` and `tabset` guesses a color there will be no output to indicate what color was picked or how.