### PR TITLE
Add --reset flag to restore original tab color

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ If you don't like the hashed selection, experiment with
 variations. You might hate `--hash js`, but find
 `--hash js_`, `--hash JS` or `--hash javascript` to be just right
 
+By default, tabset will show output indicating what color was picked
+if no color was explicitly provided, such as when using the `--hash`
+option, `--pick`, or `--all` flags. If you want to disable this
+output, you can use the `--quiet` flag, and there will be no terminal
+output indicating what color was chosen.
+
 Titles and Badges
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,14 @@ If you don't like the hashed selection, experiment with
 variations. You might hate `--hash js`, but find
 `--hash js_`, `--hash JS` or `--hash javascript` to be just right
 
+
+If you wish to restore the default tab color, use the `--reset` flag, like so:
+
+    tabset --reset
+
+The original iTerm2 tab color will be restored. This will not reset the title
+or badge.
+
 Titles and Badges
 -----------------
 

--- a/tabset.js
+++ b/tabset.js
@@ -66,6 +66,7 @@ function process_args () {
     println('       --del <name>')
     println('       --list')
     println('       --colors')
+    println('       --reset')
     println('       --help')
     println()
   }
@@ -159,6 +160,10 @@ function process_args () {
 
   if (args.init) {
     initConfigFile()
+  }
+
+  if (args.reset) {
+    resetTab()
   }
 }
 
@@ -359,6 +364,11 @@ function setTabColor (color) {
             ansiseq('6;1;bg;green;brightness;', color[1]) +
             ansiseq('6;1;bg;blue;brightness;',  color[2])
   print(cmd)
+}
+
+function resetTab () {
+  var cmd = ansiseq('6;1;bg;*;default');
+  print(cmd);
 }
 
 /**

--- a/tabset.js
+++ b/tabset.js
@@ -43,6 +43,15 @@ var config = readJSON(configpath) || { colors: {} }
 interpretConfig(config)
 process_args()
 
+/**
+ * Proxy to println that does nothing if --quiet flag is passed.
+ */
+function sayln () {
+  if (!args.quiet) {
+    println(...arguments);
+  }
+}
+
 function process_args () {
   // help requested
   if (args.help) {
@@ -66,6 +75,7 @@ function process_args () {
     println('       --del <name>')
     println('       --list')
     println('       --colors')
+    println('       --quiet')
     println('       --help')
     println()
   }
@@ -93,7 +103,7 @@ function process_args () {
       var colorNames = _.keys(colors).sort()
       var index = stringHash(args.all) % colorNames.length
       var hashColor = colorNames[index]
-      println('picked color:', hashColor)
+      sayln('picked color:', hashColor)
       col = colors[hashColor]
     }
     setTabColor(col, definedOr(args.mode, 1))
@@ -125,18 +135,18 @@ function process_args () {
       colorpick({ targetApp: 'iTerm2'},
                 function (res) {
                   addColor(args.add, rgbstr(res.rgb))
-                  println('added:', args.add)
+                  sayln('added:', args.add)
                 })
     } else if (_.size(args._) === 1) {
       addColor(args.add, args._[0])
-      println('added:', args.add)
+      sayln('added:', args.add)
     } else {
       errorExit('add what color?')
     }
   } else if (args.pick) {
     colorpick({ targetApp: 'iTerm2'},
               function (res) {
-                println('picked:', rgbstr(res.rgb))
+                sayln('picked:', rgbstr(res.rgb))
                 setTabColor(res.rgb)
               })
   }
@@ -146,7 +156,7 @@ function process_args () {
       errorExit('must give name to delete')
     }
     delColor(args.del)
-    println('deleted:', args.del)
+    sayln('deleted:', args.del)
   }
 
   if (args.list) {
@@ -289,7 +299,7 @@ function decodeColor (name) {
     if (args.hash) {
       var index = stringHash(args.hash) % colorNames.length
       var hashColor = colorNames[index]
-      println('hashed color:', hashColor)
+      sayln('hashed color:', hashColor)
       return colors[hashColor]
     }
 
@@ -300,14 +310,14 @@ function decodeColor (name) {
   // random named color
   if (name === 'random') {
     var randColor = _.sample(colorNames)
-    println('random color:', randColor)
+    sayln('random color:', randColor)
     return colors[randColor]
   }
 
   // RANDOM color - not just a random named color
   if (name === 'RANDOM') {
     var rcolor = [_.random(255), _.random(255), _.random(255) ]
-    println('RANDOM color:', rgbstr(rcolor))
+    sayln('RANDOM color:', rgbstr(rcolor))
     return rcolor
   }
 
@@ -324,20 +334,20 @@ function decodeColor (name) {
       return s.indexOf(name) >= 0
     })
     if (possibles.length === 1) {
-      println('guessing:', possibles[0])
+      sayln('guessing:', possibles[0])
       return colors[possibles[0]]
     }  else if (possibles.length > 1) {
-      println(wrap('possibly: ' + possibles.join(', ')))
+      sayln(wrap('possibly: ' + possibles.join(', ')))
       var rcolor = _.sample(possibles)
-      println('randomly picked:', rcolor)
+      sayln('randomly picked:', rcolor)
       return colors[rcolor]
     }
   }
 
   // nothing worked, use default color
-  println('no color', JSON.stringify(name), 'known')
-  println('using default:', defaultColorSpec)
-  println('use --colors option to list color names')
+  sayln('no color', JSON.stringify(name), 'known')
+  sayln('using default:', defaultColorSpec)
+  sayln('use --colors option to list color names')
   return colors['default']
 }
 


### PR DESCRIPTION
Sends the escape sequence to reset the tab color to the iTerm2 default. Fixes #3 